### PR TITLE
Diferenciar boleto bancário de boleto de convênio

### DIFF
--- a/src/BoletoWinner.php
+++ b/src/BoletoWinner.php
@@ -5,6 +5,9 @@ namespace Claudsonm\BoletoWinner;
 use BadMethodCallException;
 use Claudsonm\BoletoWinner\Exceptions\BoletoWinnerException;
 use Claudsonm\BoletoWinner\Factories\BillFactory;
+use Claudsonm\BoletoWinner\Validators\BoletoValidator;
+use Claudsonm\BoletoWinner\Validators\ConvenioValidator;
+use Throwable;
 
 /**
  * @method static bool isValidBoleto(string $barcodeOrWritableLine)
@@ -92,6 +95,70 @@ class BoletoWinner
 
             return true;
         } catch (BoletoWinnerException $exception) {
+            return false;
+        }
+    }
+
+    public static function isBoletoByBarcode(string $barcode): bool
+    {
+        try {
+            $writableLine = self::toWritableLine($barcode);
+
+            $isBoleto = (new BoletoValidator())->verifyWritableLine($writableLine);
+
+            return $isBoleto;
+
+        } catch (Throwable $e) {
+            return false;
+        }
+    }
+
+    public static function isBoletoByWritableLine(string $writableLine): bool
+    {
+        try {
+            $writableLineClean = preg_replace('/[^0-9]/', '', $writableLine);
+
+            if (empty($writableLineClean)) {
+                throw BoletoWinnerException::inputRequired();
+            }
+
+            $isBoleto = (new BoletoValidator())->verifyWritableLine($writableLineClean);
+
+            return $isBoleto;
+
+        } catch (Throwable $e) {
+            return false;
+        }
+    }
+
+    public static function isConvenioByBarcode(string $barcode): bool
+    {
+        try {
+            $writableLine = self::toWritableLine($barcode);
+
+            $isConvenio = (new ConvenioValidator())->verifyWritableLine($writableLine);
+
+            return $isConvenio;
+
+        } catch (Throwable $e) {
+            return false;
+        }
+    }
+
+    public static function isConvenioByWritableLine(string $writableLine): bool
+    {
+        try {
+            $writableLineClean = preg_replace('/[^0-9]/', '', $writableLine);
+
+            if (empty($writableLineClean)) {
+                throw BoletoWinnerException::inputRequired();
+            }
+
+            $isConvenio = (new ConvenioValidator())->verifyWritableLine($writableLineClean);
+
+            return $isConvenio;
+
+        } catch (Throwable $e) {
             return false;
         }
     }

--- a/tests/BoletoWinnerTest.php
+++ b/tests/BoletoWinnerTest.php
@@ -157,6 +157,70 @@ class BoletoWinnerTest extends TestCase
     }
 
     /** @test */
+    public function it_check_is_boleto_by_barcode_de_boleto()
+    {
+        $barcode = '23793946900000291542115092000081970400146930';
+
+        $this->assertTrue(BoletoWinner::isBoletoByBarcode($barcode));
+    }
+
+    /** @test */
+    public function it_check_is_boleto_by_barcode_de_convenio()
+    {
+        $barcode = '84660000001249800820899999319301093721978999';
+
+        $this->assertFalse(BoletoWinner::isBoletoByBarcode($barcode));
+    }
+
+    /** @test */
+    public function it_check_is_boleto_by_writable_line_de_boleto()
+    {
+        $writableLine = '23792115079200008197304001469305394690000029154';
+
+        $this->assertTrue(BoletoWinner::isBoletoByWritableLine($writableLine));
+    }
+
+    /** @test */
+    public function it_check_is_boleto_by_writable_line_de_convenio()
+    {
+        $writableLine = '846600000018249800820899999931930104937219789990';
+
+        $this->assertFalse(BoletoWinner::isBoletoByWritableLine($writableLine));
+    }
+
+    /** @test */
+    public function it_check_is_convenio_by_barcode_de_convenio()
+    {
+        $barcode = '84660000001249800820899999319301093721978999';
+
+        $this->assertTrue(BoletoWinner::isConvenioByBarcode($barcode));
+    }
+
+    /** @test */
+    public function it_check_is_convenio_by_barcode_de_boleto()
+    {
+        $barcode = '23793946900000291542115092000081970400146930';
+
+        $this->assertFalse(BoletoWinner::isConvenioByBarcode($barcode));
+    }
+
+    /** @test */
+    public function it_check_is_convenio_by_writable_line_de_convenio()
+    {
+        $writableLine = '846600000018249800820899999931930104937219789990';
+
+        $this->assertTrue(BoletoWinner::isConvenioByWritableLine($writableLine));
+    }
+
+    /** @test */
+    public function it_check_is_convenio_by_writable_line_de_boleto()
+    {
+        $writableLine = '23792115079200008197304001469305394690000029154';
+
+        $this->assertFalse(BoletoWinner::isConvenioByWritableLine($writableLine));
+    }
+
+    /** @test */
     public function it_throws_exception_when_the_method_called_do_not_exists()
     {
         $this->expectException(BadMethodCallException::class);


### PR DESCRIPTION
# Diferenciar boleto bancário de boleto de convênio

# Descrição

- Nessa task, foi desenvolvido métodos para diferenciar  boleto bancário e  boleto de convênio.

- Esse pull request ainda não soluciona a issue #2 , mas é uma alternativa para quem precisar diferenciar boleto bancário e boleto de convênio.

# Tipo de mudança

- [x] Melhoria
- [ ] Correção de bug

# Como testar ?

- Foram desenvolvidos testes automatizados para essa contribuição.